### PR TITLE
Recreate rehype react typeerror in renderer [DO NOT MERGE]

### DIFF
--- a/lib/renderer.ts
+++ b/lib/renderer.ts
@@ -7,15 +7,11 @@ import { Section } from "./Section";
 export function renderer(content: string) {
   const rendered = rehype()
     .data("settings", { fragment: true })
-    .use(
-      rehypeReact,
-      // @ts-ignore: the types of rehype-react love to not agree, don't care as long as it works
-      {
-        createElement,
-        Fragment,
-        components: { a: AutoLink, section: Section }
-      }
-    )
+    .use(rehypeReact, {
+      createElement,
+      Fragment,
+      components: { a: AutoLink, section: Section }
+    })
     .processSync(content);
 
   return rendered.result;


### PR DESCRIPTION
I cannot seem to recreate this type error anywhere else other than this repository. Even with the exact same package versions on codesandbox it does not reproduce this error.